### PR TITLE
Avoid cryptic errors and injection attacks when providing a name string for Constructs ~5

### DIFF
--- a/can-construct.js
+++ b/can-construct.js
@@ -489,7 +489,7 @@ assign(Construct, {
 		// this at all so we hide it
 
 		// Strip semicolons
-		var constructorName = shortName ? shortName.replace(/;/g, '') : 'Constructor';
+		var constructorName = shortName ? shortName.replace(/[^A-Z0-9_]/ig, '_') : 'Constructor';
 
 		// Assign a name to the constructor
 		eval('Constructor = function ' + constructorName + '() { return init.apply(this, arguments); }');

--- a/can-construct.js
+++ b/can-construct.js
@@ -5,27 +5,73 @@ var dev = require("can-util/js/dev/dev");
 var makeArray = require("can-util/js/make-array/make-array");
 var types = require('can-util/js/types/types');
 var namespace = require('can-util/namespace');
+//!steal-remove-start
 /* jshint ignore: start */
 var CanString = require('can-util/js/string/string');
-var reservedWords = [
-	"abstract",  	"else",  	"instanceof",  	"super",  
-	"boolean",  	"enum",  	"int",  	"switch",  
-	"break",  	"export",  	"interface",  	"synchronized",  
-	"byte",  	"extends",  	"let",  	"this",  
-	"case",  	"false",  	"long",  	"throw",  
-	"catch",  	"final",  	"native",  	"throws",  
-	"char",  	"finally",  	"new",  	"transient",  
-	"class",  	"float",  	"null",  	"true",  
-	"const",  	"for",  	"package",  	"try",  
-	"continue",  	"function",  	"private",  	"typeof",  
-	"debugger",  	"goto",  	"protected",  	"var",  
-	"default",  	"if",  	"public",  	"void",  
-	"delete",  	"implements",  	"return",  	"volatile",  
-	"do",  	"import",  	"short",  	"while",  
-	"double",  	"in",  	"static",  	"with"
-];
+var reservedWords = {
+	"abstract": true,
+	"boolean": true,
+	"break": true,
+	"byte": true,
+	"case": true,
+	"catch": true,
+	"char": true,
+	"class": true,
+	"const": true,
+	"continue": true,
+	"debugger": true,
+	"default": true,
+	"delete": true,
+	"do": true,
+	"double": true,
+	"else": true,
+	"enum": true,
+	"export": true,
+	"extends": true,
+	"false": true,
+	"final": true,
+	"finally": true,
+	"float": true,
+	"for": true,
+	"function": true,
+	"goto": true,
+	"if": true,
+	"implements": true,
+	"import": true,
+	"in": true,
+	"instanceof": true,
+	"int": true,
+	"interface": true,
+	"let": true,
+	"long": true,
+	"native": true,
+	"new": true,
+	"null": true,
+	"package": true,
+	"private": true,
+	"protected": true,
+	"public": true,
+	"return": true,
+	"short": true,
+	"static": true,
+	"super": true,
+	"switch": true,
+	"synchronized": true,
+	"this": true,
+	"throw": true,
+	"throws": true,
+	"transient": true,
+	"true": true,
+	"try": true,
+	"typeof": true,
+	"var": true,
+	"void": true,
+	"volatile": true,
+	"while": true,
+	"with": true
+};
 /* jshint ignore: end */
-
+//!steal-remove-end
 
 // ## construct.js
 // `Construct`
@@ -514,7 +560,7 @@ assign(Construct, {
 
 		// Strip semicolons
 		var constructorName = shortName ? shortName.replace(/[^A-Z0-9_]/ig, '_') : 'Constructor';
-		if(reservedWords.indexOf(constructorName) > -1) {
+		if(reservedWords[constructorName]) {
 			constructorName = CanString.capitalize(constructorName);
 		}
 

--- a/can-construct.js
+++ b/can-construct.js
@@ -5,17 +5,8 @@ var dev = require("can-util/js/dev/dev");
 var makeArray = require("can-util/js/make-array/make-array");
 var types = require('can-util/js/types/types');
 var namespace = require('can-util/namespace');
+/* jshint ignore: start */
 var CanString = require('can-util/js/string/string');
-
-// ## construct.js
-// `Construct`
-// _This is a modified version of
-// [John Resig's class](http://ejohn.org/blog/simple-javascript-inheritance/).
-// It provides class level inheritance and callbacks._
-// A private flag used to initialize a new class instance without
-// initializing it's bindings.
-var initializing = 0;
-
 var reservedWords = [
 	"abstract",  	"else",  	"instanceof",  	"super",  
 	"boolean",  	"enum",  	"int",  	"switch",  
@@ -33,6 +24,18 @@ var reservedWords = [
 	"do",  	"import",  	"short",  	"while",  
 	"double",  	"in",  	"static",  	"with"
 ];
+/* jshint ignore: end */
+
+
+// ## construct.js
+// `Construct`
+// _This is a modified version of
+// [John Resig's class](http://ejohn.org/blog/simple-javascript-inheritance/).
+// It provides class level inheritance and callbacks._
+// A private flag used to initialize a new class instance without
+// initializing it's bindings.
+var initializing = 0;
+
 
 
 /**

--- a/can-construct.js
+++ b/can-construct.js
@@ -5,6 +5,7 @@ var dev = require("can-util/js/dev/dev");
 var makeArray = require("can-util/js/make-array/make-array");
 var types = require('can-util/js/types/types');
 var namespace = require('can-util/namespace');
+//!steal-remove-start
 var CanString = require('can-util/js/string/string');
 var reservedWords = {
 	"abstract": true,
@@ -69,6 +70,7 @@ var reservedWords = {
 	"with": true
 };
 var constructorNameRegex = /[^A-Z0-9_]/gi;
+//!steal-remove-end
 
 // ## construct.js
 // `Construct`
@@ -79,6 +81,7 @@ var constructorNameRegex = /[^A-Z0-9_]/gi;
 // initializing it's bindings.
 var initializing = 0;
 
+//!steal-remove-start
 var namedCtor = (function(cache){
 	return function(name, fn) {
 		return ((name in cache) ? cache[name] : cache[name] = new Function(
@@ -86,6 +89,7 @@ var namedCtor = (function(cache){
 		))( fn );
 	};
 }({}));
+//!steal-remove-end
 
 /**
  * @add can-construct
@@ -560,10 +564,12 @@ assign(Construct, {
 		// new Function() is significantly faster than eval() here.
 
 		// Strip semicolons
+		//!steal-remove-start
 		var constructorName = shortName ? shortName.replace(constructorNameRegex, '_') : 'Constructor';
 		if(reservedWords[constructorName]) {
 			constructorName = CanString.capitalize(constructorName);
 		}
+		//!steal-remove-end
 
 		// The dummy class constructor.
 		function init() {
@@ -585,7 +591,9 @@ assign(Construct, {
 				Constructor.newInstance.apply(Constructor, arguments);
 			}
 		}
-		Constructor = namedCtor( constructorName, init );
+		Constructor = typeof namedCtor === "function" ?
+			namedCtor( constructorName, init ) :
+			function() { return init.apply(this, arguments); };
 
 		// Copy old stuff onto class (can probably be merged w/ inherit)
 		for (var propName in _super_class) {

--- a/can-construct.js
+++ b/can-construct.js
@@ -84,7 +84,7 @@ var namedCtor = (function(cache){
 		return ((name in cache) ? cache[name] : cache[name] = new Function(
 			"__", "function "+name+"(){return __.apply(this,arguments)};return "+name
 		))( fn );
-	}
+	};
 }({}));
 
 /**

--- a/can-construct.js
+++ b/can-construct.js
@@ -5,6 +5,7 @@ var dev = require("can-util/js/dev/dev");
 var makeArray = require("can-util/js/make-array/make-array");
 var types = require('can-util/js/types/types');
 var namespace = require('can-util/namespace');
+var CanString = require('can-util/js/string/string');
 
 // ## construct.js
 // `Construct`
@@ -14,6 +15,26 @@ var namespace = require('can-util/namespace');
 // A private flag used to initialize a new class instance without
 // initializing it's bindings.
 var initializing = 0;
+
+var reservedWords = [
+	"abstract",  	"else",  	"instanceof",  	"super",  
+	"boolean",  	"enum",  	"int",  	"switch",  
+	"break",  	"export",  	"interface",  	"synchronized",  
+	"byte",  	"extends",  	"let",  	"this",  
+	"case",  	"false",  	"long",  	"throw",  
+	"catch",  	"final",  	"native",  	"throws",  
+	"char",  	"finally",  	"new",  	"transient",  
+	"class",  	"float",  	"null",  	"true",  
+	"const",  	"for",  	"package",  	"try",  
+	"continue",  	"function",  	"private",  	"typeof",  
+	"debugger",  	"goto",  	"protected",  	"var",  
+	"default",  	"if",  	"public",  	"void",  
+	"delete",  	"implements",  	"return",  	"volatile",  
+	"do",  	"import",  	"short",  	"while",  
+	"double",  	"in",  	"static",  	"with"
+];
+
+
 /**
  * @add can-construct
  */
@@ -490,6 +511,9 @@ assign(Construct, {
 
 		// Strip semicolons
 		var constructorName = shortName ? shortName.replace(/[^A-Z0-9_]/ig, '_') : 'Constructor';
+		if(reservedWords.indexOf(constructorName) > -1) {
+			constructorName = CanString.capitalize(constructorName);
+		}
 
 		// Assign a name to the constructor
 		eval('Constructor = function ' + constructorName + '() { return init.apply(this, arguments); }');

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -163,17 +163,19 @@ test("setup called with original arguments", function(){
 test("legacy namespace strings (A.B.C) accepted", function() {
 
 	var Type = Construct.extend("Foo.Bar.Baz");
+	var expectedValue = ~steal.config("env").indexOf("production") ? "" : "Foo_Bar_Baz";
 
 	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain");
-	equal(Type.name, "Foo_Bar_Baz", "Name becomes underscored");
+	equal(Type.name, expectedValue, "Name becomes underscored");
 });
 
 test("reserved words accepted", function() {
 
 	var Type = Construct.extend("const");
+	var expectedValue = ~steal.config("env").indexOf("production") ? "" : "Const";
 
 	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain");
-	equal(Type.name, "Const", "Name becomes capitalized");
+	equal(Type.name, expectedValue, "Name becomes capitalized");
 });
 
 

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -164,7 +164,7 @@ test("legacy namespace strings (A.B.C) accepted", function() {
 
 	var Type = Construct.extend("Foo.Bar.Baz");
 
-	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain")
+	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain");
 	equal(Type.name, "Foo_Bar_Baz", "Name becomes underscored");
 });
 
@@ -172,27 +172,31 @@ test("reserved words accepted", function() {
 
 	var Type = Construct.extend("const");
 
-	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain")
+	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain");
 	equal(Type.name, "Const", "Name becomes capitalized");
 });
 
 
 test("basic injection attacks thwarted", function() {
+
+	var rootToken = typeof window === "undefined" ? "global" : "window";
+	var rootObject = typeof window === "undefined" ? global : window;
+
 	// check for injection
 	var expando = "foo" + Math.random().toString(10).slice(2);
 	var MalignantType;
 	try {
-		MalignantType = Construct.extend("(){};self." + expando + "='bar';var f=function");
+		MalignantType = Construct.extend("(){};" + rootToken + "." + expando + "='bar';var f=function");
 	} catch(e) { // ok if it fails
 	} finally {
-		equal(self[expando], undefined, "Injected code doesn't run");
+		equal(rootObject[expando], undefined, "Injected code doesn't run");
 	}
-	delete self[expando];
+	delete rootObject[expando];
 	try {
-		MalignantType = Construct.extend("(){},self." + expando + "='baz',function");
+		MalignantType = Construct.extend("(){}," + rootToken + "." + expando + "='baz',function");
 	} catch(e) {
 	} finally {
-		equal(self[expando], undefined, "Injected code doesn't run");
+		equal(rootObject[expando], undefined, "Injected code doesn't run");
 	}
 
-})
+});

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -168,6 +168,15 @@ test("legacy namespace strings (A.B.C) accepted", function() {
 	equal(Type.name, "Foo_Bar_Baz", "Name becomes underscored");
 });
 
+test("reserved words accepted", function() {
+
+	var Type = Construct.extend("const");
+
+	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain")
+	equal(Type.name, "Const", "Name becomes capitalized");
+});
+
+
 test("basic injection attacks thwarted", function() {
 	// check for injection
 	var expando = "foo" + Math.random().toString(10).slice(2);

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -159,3 +159,31 @@ test("setup called with original arguments", function(){
 
 	Construct.extend(o1, o2);
 });
+
+test("legacy namespace strings (A.B.C) accepted", function() {
+
+	var Type = Construct.extend("Foo.Bar.Baz");
+
+	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain")
+	equal(Type.name, "Foo_Bar_Baz", "Name becomes underscored");
+});
+
+test("basic injection attacks thwarted", function() {
+	// check for injection
+	var expando = "foo" + Math.random().toString(10).slice(2);
+	var MalignantType;
+	try {
+		MalignantType = Construct.extend("(){};self." + expando + "='bar';var f=function");
+	} catch(e) { // ok if it fails
+	} finally {
+		equal(self[expando], undefined, "Injected code doesn't run");
+	}
+	delete self[expando];
+	try {
+		MalignantType = Construct.extend("(){},self." + expando + "='baz',function");
+	} catch(e) {
+	} finally {
+		equal(self[expando], undefined, "Injected code doesn't run");
+	}
+
+})


### PR DESCRIPTION
This PR:
- converts all non-word-characters and dollarsigns to underscores, so legacy namespaced names like "Foo.Bar" don't cause crashes with "Unexpected token ."
- Avoids injection attacks that don't use semicolons (with existing master you can do the same injection attacks with commas, for example)
- Converts constructor names that are reserved keywords with [the 3.0 non-namespace equivalent of] can.capitalize, to make them valid function names.

And this is because I'm sick of fighting against how the current impl treats legacy code.
