### PR TITLE
Function.prototype.name is not available in IE < 12

### DIFF
--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -166,7 +166,9 @@ test("legacy namespace strings (A.B.C) accepted", function() {
 	var expectedValue = ~steal.config("env").indexOf("production") ? "" : "Foo_Bar_Baz";
 
 	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain");
-	equal(Type.name, expectedValue, "Name becomes underscored");
+	if (Function.prototype.name) {
+		equal(Type.name, expectedValue, "Name becomes underscored");
+	}
 });
 
 test("reserved words accepted", function() {
@@ -175,7 +177,9 @@ test("reserved words accepted", function() {
 	var expectedValue = ~steal.config("env").indexOf("production") ? "" : "Const";
 
 	ok(new Type() instanceof Construct, "No unexpected behavior in the prototype chain");
-	equal(Type.name, expectedValue, "Name becomes capitalized");
+	if (Function.prototype.name) {
+		equal(Type.name, expectedValue, "Name becomes capitalized");
+	}
 });
 
 

--- a/test.html
+++ b/test.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <title>can-construct</title>
 <script src="./node_modules/steal/steal.js" main="can-construct/can-construct_test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
Closes https://github.com/canjs/can-construct/issues/17.