### PR TITLE
Remove cssify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,6 @@
     "release:pre": "npm version prerelease && npm publish"
   },
   "main": "can-construct",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "canjs-plugin",
@@ -51,7 +41,6 @@
   "devDependencies": {
     "bit-docs": "0.0.7",
     "jshint": "^2.9.1",
-    "cssify": "^1.0.2",
     "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.16.0",


### PR DESCRIPTION
This package doesn't use css at all. Having it as a transform breaks
Browserify. This fixes #19