### PR TITLE
Use Object.defineProperty to avoid calling base setters

### DIFF
--- a/can-construct.js
+++ b/can-construct.js
@@ -309,7 +309,7 @@ assign(Construct, {
 	// this should be used for patching other objects
 	// the super plugin overwrites this
 	_overwrite: function (what, oldProps, propName, val) {
-		what[propName] = val;
+		Object.defineProperty(what, propName, {value: val, configurable: true, enumerable: true, writable: true});
 	},
 	// Set `defaults` as the merger of the parent `defaults` and this
 	// object's `defaults`. If you overwrite this method, make sure to
@@ -685,7 +685,7 @@ assign(Construct, {
  * 					return [$(element)]
  * 			}
  * 	});
- * 
+ *
  * 	MyWidget = WidgetFactory.extend({
  * 			init: function($el){
  * 					$el.html("My Widget!!")

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -206,3 +206,22 @@ test("basic injection attacks thwarted", function() {
 	}
 
 });
+
+QUnit.test("setters not invoked on extension (#28)", function(){
+
+	var extending = true;
+	var Base = Construct.extend("Base",{
+		set something(value){
+			QUnit.ok(!extending, "called when not extending");
+		},
+		get something(){
+
+		}
+	});
+
+	Base.extend("Extended",{
+		something: "value"
+	});
+	extending = false;
+	new Base().something = "foo";
+});


### PR DESCRIPTION
fixes #28 and https://github.com/canjs/can-define/issues/117