### PR TITLE
Implement "can.name" symbol behavior

### DIFF
--- a/can-construct.js
+++ b/can-construct.js
@@ -4,6 +4,8 @@ var deepAssign = require("can-util/js/deep-assign/deep-assign");
 var dev = require("can-util/js/dev/dev");
 var makeArray = require("can-util/js/make-array/make-array");
 var namespace = require('can-namespace');
+var canReflect = require("can-reflect");
+var canSymbol = require("can-symbol");
 //!steal-remove-start
 var CanString = require('can-util/js/string/string');
 var reservedWords = {
@@ -528,35 +530,35 @@ assign(Construct, {
 	 * dog.speak(); // 'woof'
 	 * blackMamba.speak(); // 'ssssss'
 	 * ```
-	 * 
+	 *
 	 * ## Alternative value for a new instance
-	 * 
+	 *
 	 * Sometimes you may want to return some custom value instead of a new object when creating an instance of your class.
 	 * For example, you want your class to act as a singleton, or check whether an item with the given id was already
 	 * created and return an existing one from your cache store (e.g. using [can-connect/constructor/store/store]).
-	 * 
+	 *
 	 * To achieve this you can return [can-construct.ReturnValue] from `setup` method of your class.
-	 * 
+	 *
 	 * Lets say you have `myStore` to cache all newly created instances. And if an item already exists you want to merge
 	 * the new data into the existing instance and return the updated instance.
-	 * 
+	 *
 	 * ```
 	 * var myStore = {};
-	 * 
+	 *
 	 * var Item = Construct.extend({
 	 *     setup: function(params){
 	 *         if (myStore[params.id]){
 	 *             var item = myStore[params.id];
-	 *             
+	 *
 	 *             // Merge new data to the existing instance:
 	 *             Object.assign(item, params);
-	 *             
+	 *
 	 *             // Return the updated item:
 	 *             return new Construct.ReturnValue( item );
 	 *         } else {
 	 *             // Save to cache store:
 	 *             myStore[this.id] = this;
-	 *             
+	 *
 	 *             return [params];
 	 *         }
 	 *     },
@@ -564,7 +566,7 @@ assign(Construct, {
 	 *         Object.assign(this, params);
 	 *     }
 	 * });
-	 * 
+	 *
 	 * var item_1  = new Item( {id: 1, name: "One"} );
 	 * var item_1a = new Item( {id: 1, name: "OnePlus"} )
 	 * ```
@@ -709,23 +711,23 @@ assign(Construct, {
 	/**
 	 * @function can-construct.ReturnValue ReturnValue
 	 * @parent can-construct.static
-	 * 
+	 *
 	 * Use to overwrite the return value of new Construct(...).
-	 * 
+	 *
 	 * @signature `new Construct.ReturnValue( value )`
-	 * 
+	 *
 	 *   This constructor function can be used for creating a return value of the `setup` method.
 	 *   [can-construct] will check if the return value is an instance of `Construct.ReturnValue`.
 	 *   If it is then its `value` will be used as the new instance.
-	 * 
+	 *
 	 *   @param {Object} value A value to be used for a new instance instead of a new object.
-	 * 
+	 *
 	 *   ```
 	 *   var Student = function( name, school ){
 	 *       this.name = name;
 	 *       this.school = school;
-	 *   } 
-	 * 
+	 *   }
+	 *
 	 *   var Person = Construct.extend({
 	 *       setup: function( options ){
 	 *           if (options.school){
@@ -735,9 +737,9 @@ assign(Construct, {
 	 *           }
 	 *       }
 	 *   });
-	 * 
+	 *
 	 *   var myPerson = new Person( {name: "Ilya", school: "PetrSU"} );
-	 * 
+	 *
 	 *   myPerson instanceof Student // => true
 	 *   ```
    */
@@ -853,5 +855,9 @@ Construct.prototype.setup = function () {};
  * the inheritance chain.
  */
 Construct.prototype.init = function () {};
+
+canReflect.set(Construct.prototype, canSymbol.for("can.name"), function() {
+	return this.constructor.name + (this._cid ? "(" + this._cid + ")" : "");
+});
 
 module.exports = namespace.Construct = Construct;

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -2,6 +2,7 @@ QUnit = require('steal-qunit');
 var Construct = require('can-construct');
 var dev = require("can-util/js/dev/");
 var makeArray = require("can-util/js/make-array/");
+var canSymbol = require("can-symbol");
 
 QUnit.module('can-construct', {
 	setup: function () {
@@ -259,4 +260,33 @@ QUnit.test("return alternative value on setup (full case)", function(){
 	QUnit.equal(new Person({age: 12}).isStudent, false, "Age 12 cannot be a student");
 	QUnit.equal(new Person({age: 30}).isStudent, true, "Age 20 can be a student");
 	QUnit.ok(new Person({age: 30}) instanceof Student, "Should return an instance of Student");
+});
+
+QUnit.test("default implementation of canSymbol('can.name')", function(assert) {
+	var AnonCtor = Construct.extend({});
+	var Person = Construct.extend("Person", {});
+
+	var getName = function(instance) {
+		return instance[canSymbol.for("can.name")]();
+	};
+
+	assert.equal(
+		getName(new AnonCtor()),
+		"Constructor",
+		"should return the default constructor name"
+	);
+
+	assert.equal(
+		getName(new Person()),
+		"Person",
+		"should return the constructor short name"
+	);
+
+	var person = new Person();
+	person._cid = 1;
+	assert.equal(
+		getName(person),
+		"Person(1)",
+		"should decorate the name with cid if present"
+	);
 });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "dependencies": {
     "can-namespace": "1.0.0",
+    "can-reflect": "^1.4.5",
+    "can-symbol": "canjs/can-symbol#friendly-name",
     "can-types": "^1.1.0",
     "can-util": "^3.9.0"
   },


### PR DESCRIPTION
** do not merge yet **

@phillipskevin 

a) I pointed can-symbol to my branch, what do you usually do? I guess we need to release can-symbol and then update this PR. 

b) I wasn't sure about the `_cid` part since it's not default behavior of Construct, should we still check if exists in case someone is using `can-cid` manually? 

