### PR TITLE
Sets Constructor.name to shortName

### DIFF
--- a/can-construct.js
+++ b/can-construct.js
@@ -665,6 +665,16 @@ assign(Construct, {
 		});
 
 		if (shortName !== undefined) {
+			if (Object.getOwnPropertyDescriptor) {
+				var desc = Object.getOwnPropertyDescriptor(Constructor, 'name');
+				if (!desc || desc.configurable) {
+					Object.defineProperty(
+						Constructor,
+						'name',
+						{ writable: true, value: shortName, configurable: true }
+					);
+				}
+			}
 			Constructor.shortName = shortName;
 		}
 		// Make sure our prototype looks nice.

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -73,7 +73,9 @@ test('namespaces', function () {
 
 	ok(!window.Bar, "not added to global namespace");
 
-
+  if (Object.getOwnPropertyDescriptor) {
+  	equal(fb.name, 'Bar', 'name is right');
+  }
 	equal(fb.shortName, 'Bar', 'short name is right');
 });
 test('setups', function () {

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -73,9 +73,9 @@ test('namespaces', function () {
 
 	ok(!window.Bar, "not added to global namespace");
 
-  if (Object.getOwnPropertyDescriptor) {
-  	equal(fb.name, 'Bar', 'name is right');
-  }
+	if (Object.getOwnPropertyDescriptor) {
+		equal(fb.name, 'Bar', 'name is right');
+	}
 	equal(fb.shortName, 'Bar', 'short name is right');
 });
 test('setups', function () {


### PR DESCRIPTION
The uglified/minified version loses the `name` property on build. This change fixes that problem.
We're using `typeforce` package on our client to check types in a certain flow and it fails without this change.
