### PR TITLE
nested objects as default should not be overwritten by children types

### DIFF
--- a/can-construct.js
+++ b/can-construct.js
@@ -399,7 +399,7 @@ canReflect.assignMap(Construct, {
 	 * ```
 	 */
 	setup: function (base) {
-		var defaults = base.default ? canReflect.serialize(base.defaults) : {};
+		var defaults = base.defaults ? canReflect.serialize(base.defaults) : {};
 		this.defaults = canReflect.assignDeepMap(defaults,this.defaults);
 	},
 	// Create's a new `class` instance without initializing by setting the

--- a/can-construct.js
+++ b/can-construct.js
@@ -399,7 +399,7 @@ canReflect.assignMap(Construct, {
 	 * ```
 	 */
 	setup: function (base) {
-		var defaults = canReflect.assignDeepMap({},base.defaults);
+		var defaults = base.default ? canReflect.serialize(base.defaults) : {};
 		this.defaults = canReflect.assignDeepMap(defaults,this.defaults);
 	},
 	// Create's a new `class` instance without initializing by setting the

--- a/can-construct_test.js
+++ b/can-construct_test.js
@@ -298,3 +298,24 @@ QUnit.test("Has default init, setup functions", function(){
 	QUnit.equal(typeof instance.init, "function", "has init");
 	QUnit.equal(typeof instance.setup, "function", "has setup");
 });
+
+QUnit.test("Extending should not update defaults nested objects", function() {
+	var Parent = Construct.extend({
+		defaults: {
+			obj: {
+				foo: "Bar"
+			}
+		}
+	},{});
+
+	var Child = Parent.extend({
+		defaults: {
+			obj: {
+				foo: "Baz"
+			}
+		}
+	}, {});
+
+	QUnit.equal(Parent.defaults.obj.foo, "Bar", "Base defaults are not changed");
+	QUnit.equal(Child.defaults.obj.foo, "Baz", "Child defaults get defaults right");
+});


### PR DESCRIPTION
Fix nested objects as defaults, example:
```js
	var Parent = Construct.extend({
		defaults: {
			obj: {
				foo: "Bar"
			}
		}
	},{});

	var Child = Parent.extend({
		defaults: {
			obj: {
				foo: "Baz"
			}
		}
	}, {});
```
```Parent.defaults.obj.foo``` should not be changed to `Baz`

Fixes #65